### PR TITLE
Use height and width attrs when viewBox is not present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,13 @@ function createSymbol(code, id) {
   const markup = cheerio.load(code, { xmlMode: true })
   const svgMarkup = markup('svg')
   const symbolId = svgMarkup.find('title').text() || id
+  const viewBox = svgMarkup.attr('viewBox')
+    || [0, 0, svgMarkup.attr('width'), svgMarkup.attr('height')].join(' ')
 
   markup('svg').replaceWith('<symbol/>')
   markup('symbol')
     .attr('id', symbolId)
-    .attr('viewBox', svgMarkup.attr('viewBox'))
+    .attr('viewBox', viewBox)
     .append(svgMarkup.children())
 
   return markup.xml('symbol')


### PR DESCRIPTION
Some of the older SVGs that our application uses were exported were exported with a `height` and `width`, but no `viewBox` causing this plugin to break. The "correct" way to fix this problem would be to correct the SVG sources, but that was not something I wanted to pursue.

As a non-perfect fallback for this situation, use the height and width attributes to construct a viewBox string so that compilation can continue.

I didn't add a test for this as I was reluctant to add another fixture to the repo, but can if you prefer.

I also thought about adding a console warning for SVGs missing the `viewBox` attr but thought that might just be annoying/heavy-handed.