### PR TITLE
Sort loaded SVGs for deterministic output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default function svgSprite(options = {}) {
     },
     async writeBundle() {
       if (loadedSvgs.size) {
-        const symbols = [...loadedSvgs.values()].map((id) => convertedSvgs.get(id))
+        const symbols = [...loadedSvgs.values()].map((id) => convertedSvgs.get(id)).sort()
         const { data } = await svgo.optimize(createSprite(symbols))
 
         await fs.outputFile(`${outputFolder}/sprites.svg`, data)


### PR DESCRIPTION
In the case of many SVGs in a project, the order in which they are completely processed is non-deterministic. This results in a `sprites.svg` that changes from build to build. In the case of Yarn v2 (when referencing a Git project that is built using this plugin), this breaks the expectation that the expected checksum of the project tarball will not change from one environment to another.

This PR sorts the array of symbols before emitting them to `sprites.svg`. I have confirmed that repeated builds with this change keep the same checksum.